### PR TITLE
add gov.uk & skillsmap

### DIFF
--- a/_posts/2016-07-11-engineering-ladders-links-elsewhere.md
+++ b/_posts/2016-07-11-engineering-ladders-links-elsewhere.md
@@ -229,33 +229,32 @@ tracks for many of the roles.
 
 #### [Tes Global][tes-global-talk]
 
-Tes Global designed their engineering ladder differently than most of the others.
-Rather than using career levels, they use a modified Dreyfus model to show skill 
-progression within a set of high-level categories. Career levels can then be laid over 
-this map to provide more flexibility than most other engineering ladders.
-The downside to this approach is it is more complex than others and requires tooling support to
-get the most value and does not scale past 10 - 15 engineers without tooling.
-You can look at the [original map][tes-global-original-map] and the [evolved map][tes-global-evolved-map] to get an idea
-of how this worked in practice. The evolved map improves scalability by adding acceptance criteria to each skill. 
-There is a [talk by David Morgantini](tes-global-talk) that explains in greater detail how this 
-engineering ladder was used at Tes to help drive growth and retention.
+Tes Global designed their engineering ladder differently than most of the others. Rather than using career levels,
+they use a modified Dreyfus model to show skill progression within a set of high-level categories. Career levels
+can then be laid over this map to provide more flexibility than most other engineering ladders. The 
+[original][tes-global-original-map] and the [evolved map][tes-global-evolved-map], which has acceptance criteria
+for each skill, provide an idea of how this worked in practice. There is also a [talk by David Morgantini][tes-global-talk]
+that explains in greater detail how this engineering ladder was used at Tes.
+
+The downside to this approach is it is more complex than others and requires tooling support and does not scale
+past 10 - 15 engineers without such. Tes implemented and [open-sourced a tool][tes-global-skills-matrix] to manage
+this kind of ladder.
+
 
 <a name="skillsmap"></a>
 
 #### [SkillsMap.io][skillsmap-io]
 
-SkillsMap.io is not a engineering ladder itself, but rather, a tool that allows teams to build, 
-and get maximum value from them. It was born out of the engineering ladder created at Tes Global,
-and is a fork of the [open source tool](tes-global-skills-matrix) they released in late 2017.
+SkillsMap.io is not a engineering ladder itself, but rather, a tool that allows teams to build their own engineering
+ladder. It emerged out of the engineering ladder created at [Tes Global](#tes-global-ladder), and is a fork of the
+[open source tool][tes-global-skills-matrix] they released in late 2017.
+
 The tool provides: 
 * a structured and scalable evaluation & review process
 * the ability to create custom skills maps or engineering ladders
 * skill gap reporting & insights
 * the ability to evaluate candidates prior to interview
 
-It is flexible enough to support most of the other engineering ladders listed on this
-page. The SkillsMap team also offer a consultancy service to help reduce the effort required to build an 
-engineering ladder that is meaningful for you and your organization.
 
 ### Missing a ladder?
 

--- a/_posts/2016-07-11-engineering-ladders-links-elsewhere.md
+++ b/_posts/2016-07-11-engineering-ladders-links-elsewhere.md
@@ -40,7 +40,6 @@ the roles' and positions' classifications mean for you and your organization.
 * [Kickstarter](#kickstarter-ladder)
 * [Urban Airship](#urbanairship-ladder)
 * [Intent Media](#intent-ladder)
-* [Chartbeat](#chartbeat-ladder)
 * [Spotify](#spotify-ladder)
 * [Charles Krempeaux](#charles-ladder)
 * [Fog Creek](#fogcreek-ladder)
@@ -48,6 +47,8 @@ the roles' and positions' classifications mean for you and your organization.
 * [Patreon](#patreon-ladder)
 * [Songkick](#songkick-ladder)
 * [Medium](#medium-ladder)
+* [GOV.UK](#govuk-ladder)
+* [SkillsMap.io](#skillsmap)
 
 If you're aware of a ladder, that's shared somewhere but not on this list,
 please [contact me](/contact/) or [send a pull request][github-source].
@@ -119,21 +120,6 @@ It provides a lot of context about how engineering in general is structured at
 Intent Media and all positions are described in a concise yet extensive prose.
 It's very well structured, offers a lot of inspiration and conveys deep thinking
 that lead towards the ladder.
-
-<a name="chartbeat-ladder"></a>
-
-#### [Chartbeat][chartbeat-ladder]
-
-Chartbeat's ladder is also built around four pillars, namely
-_"Responsibilities"_, _"Expertise"_, _"Qualities"_ and _"Objectives"_.
-Furthermore it's actually three different ladders for the paths _Backend_,
-_Frontend/Design_ and _Data Science_.
-
-The descriptions are very compact, thus require probably quite some effort in
-communicating and to create a shared understanding. Which of course is not
-necessarily a bad thing, as it's nearly impossible to formulate a ladder that
-doesn't trigger or even requires a discussion around it's assumptions and
-definitions.
 
 <a name="spotify-ladder"></a>
 
@@ -220,6 +206,41 @@ The Growth Framework describes it with the following words:
 > mistakes or fail to appropriately value work. The appeals process outlines the way in which engineers can challenge a
 > decision they consider to be inaccurate.
 
+<a name="govuk-ladder"></a>
+
+#### [GOV.UK][gov-uk-professional-capability-framework]
+
+The government of the United Kingdom released perhaps the most comprehensive career ladder/growth framework available.
+The skills are entirely generic so will require a degree of effort to reduce subjectivity and ensure consistency of
+interpretation. It covers an astonishing 38 different data and technology roles including management and technical
+tracks for many of the roles.
+
+> Anyone can use the Capability Framework to:
+>
+> * learn about what different roles do in government  
+> * understand what skills are needed by professionals in particular jobs  
+> * identify skills that need development to help career progression  
+> * assess skills in preparation for performance reviews  
+> * create effective job adverts  
+> * carry out HR and workforce planning  
+
+<a name="skillsmap"></a>
+
+#### [SkillsMap.io][skillsmap-io]
+
+SkillsMap.io is not a career ladder itself, but a tool that allows teams to build, 
+and get maximum value from them. It was born out of the [original career 
+ladder](https://docs.google.com/spreadsheets/u/1/d/12Dp1loqTibtiECiBAVFoOTKV5wPnDAGOrmxdrY_bkj4/edit?usp=gmail#gid=0) 
+created at Tes Global by former VP of Engineering David Morgantini.
+There is a [talk by David Morgantini](https://www.youtube.com/watch?v=v6wAlxrhC80) that explains how the 
+career ladder was used at Tes to help drive growth and retention. David is now working on SkillsMap 
+(originally the open source tool built at Tes) which can help companies with 
+scaling their usage of a career ladder.  It is fully customizable and can support all 
+of the career ladders listed on this page.  In addition to providing a structure around 
+evaluations it also aids in reporting for skill gaps and staff liquidity and gives the ability 
+to evaluate candidates prior to interviews giving a more structured interview process.
+The SkillsMap team also offer a consultancy service to help reduce the effort required to build an 
+engineering ladder that is meaningful for you and your organization.
 
 ### Missing a ladder?
 
@@ -246,7 +267,6 @@ Lots of 😍 to the following contributors far:
 [fogcreek-ladder]: http://joelonsoftware.com/articles/ladder.html
 [urbanairship-ladder]: https://github.com/urbanairship/techladder
 [intent-ladder]: https://intentmedia.com/the-intent-media-engineering-ladders/
-[chartbeat-ladder]: http://engineering.chartbeat.com/2015/06/05/engineering-ladders/
 [spotify-ladder1]: https://labs.spotify.com/2016/02/08/technical-career-path/
 [spotify-ladder2]: https://labs.spotify.com/2016/02/15/spotify-technology-career-steps/
 [spotify-ladder3]: https://labs.spotify.com/2016/02/22/things-we-learned-creating-technology-career-steps/
@@ -257,3 +277,5 @@ Lots of 😍 to the following contributors far:
 [songkick-ladder-blogpost]: https://blog.songkick.com/building-a-growth-framework-2464435e9e46
 [songkick-ladder]: https://www.songkick.com/downloads/growth-framework/sk-growth-framework.pdf
 [medium-ladder-blogpost]: https://medium.com/s/engineering-growth-framework
+[gov-uk-professional-capability-framework]: https://www.gov.uk/government/collections/digital-data-and-technology-profession-capability-framework
+[skillsmap-io]: https://www.skillsmap.io

--- a/_posts/2016-07-11-engineering-ladders-links-elsewhere.md
+++ b/_posts/2016-07-11-engineering-ladders-links-elsewhere.md
@@ -48,6 +48,7 @@ the roles' and positions' classifications mean for you and your organization.
 * [Songkick](#songkick-ladder)
 * [Medium](#medium-ladder)
 * [GOV.UK](#govuk-ladder)
+* [Tes Global](#tes-global-ladder)
 * [SkillsMap.io](#skillsmap)
 
 If you're aware of a ladder, that's shared somewhere but not on this list,
@@ -224,22 +225,36 @@ tracks for many of the roles.
 > * create effective job adverts  
 > * carry out HR and workforce planning  
 
+<a name="tes-global-ladder"></a>
+
+#### [Tes Global][tes-global-talk]
+
+Tes Global designed their engineering ladder differently than most of the others.
+Rather than using career levels, they use a modified Dreyfus model to show skill 
+progression within a set of high-level categories. Career levels can then be laid over 
+this map to provide more flexibility than most other engineering ladders.
+The downside to this approach is it is more complex than others and requires tooling support to
+get the most value and does not scale past 10 - 15 engineers without tooling.
+You can look at the [original map][tes-global-original-map] and the [evolved map][tes-global-evolved-map] to get an idea
+of how this worked in practice. The evolved map improves scalability by adding acceptance criteria to each skill. 
+There is a [talk by David Morgantini](tes-global-talk) that explains in greater detail how this 
+engineering ladder was used at Tes to help drive growth and retention.
+
 <a name="skillsmap"></a>
 
 #### [SkillsMap.io][skillsmap-io]
 
-SkillsMap.io is not a career ladder itself, but a tool that allows teams to build, 
-and get maximum value from them. It was born out of the [original career 
-ladder](https://docs.google.com/spreadsheets/u/1/d/12Dp1loqTibtiECiBAVFoOTKV5wPnDAGOrmxdrY_bkj4/edit?usp=gmail#gid=0) 
-created at Tes Global by former VP of Engineering David Morgantini.
-There is a [talk by David Morgantini](https://www.youtube.com/watch?v=v6wAlxrhC80) that explains how the 
-career ladder was used at Tes to help drive growth and retention. David is now working on SkillsMap 
-(originally the open source tool built at Tes) which can help companies with 
-scaling their usage of a career ladder.  It is fully customizable and can support all 
-of the career ladders listed on this page.  In addition to providing a structure around 
-evaluations it also aids in reporting for skill gaps and staff liquidity and gives the ability 
-to evaluate candidates prior to interviews giving a more structured interview process.
-The SkillsMap team also offer a consultancy service to help reduce the effort required to build an 
+SkillsMap.io is not a engineering ladder itself, but rather, a tool that allows teams to build, 
+and get maximum value from them. It was born out of the engineering ladder created at Tes Global,
+and is a fork of the [open source tool](tes-global-skills-matrix) they released in late 2017.
+The tool provides: 
+* a structured and scalable evaluation & review process
+* the ability to create custom skills maps or engineering ladders
+* skill gap reporting & insights
+* the ability to evaluate candidates prior to interview
+
+It is flexible enough to support most of the other engineering ladders listed on this
+page. The SkillsMap team also offer a consultancy service to help reduce the effort required to build an 
 engineering ladder that is meaningful for you and your organization.
 
 ### Missing a ladder?
@@ -247,9 +262,10 @@ engineering ladder that is meaningful for you and your organization.
 If you're aware of a ladder, that's shared somewhere, please [contact
 me](/contact/) or [send a pull request][github-source].
 
-Lots of 😍 to the following contributors far:
+Lots of 😍 to the following contributors so far:
 - [Uli Stroetz](https://github.com/benjmin-r/squeakyvessel.com/pull/2)
 - [Sven Kloppenburg](https://github.com/benjmin-r/squeakyvessel.com/pull/1)
+- [David Morgantini](https://github.com/benjmin-r/squeakyvessel.com/pull/3)
 
 [codecraft]: http://codecraft.vaamo.de
 [rtr]: https://www.renttherunway.com/
@@ -279,3 +295,7 @@ Lots of 😍 to the following contributors far:
 [medium-ladder-blogpost]: https://medium.com/s/engineering-growth-framework
 [gov-uk-professional-capability-framework]: https://www.gov.uk/government/collections/digital-data-and-technology-profession-capability-framework
 [skillsmap-io]: https://www.skillsmap.io
+[tes-global-original-map]: https://docs.google.com/spreadsheets/u/1/d/12Dp1loqTibtiECiBAVFoOTKV5wPnDAGOrmxdrY_bkj4/edit?usp=sharing
+[tes-global-evolved-map]: https://docs.google.com/spreadsheets/d/1OUO5s45mD-ReRPtJp2V65mclMHpUb7iMIuF6tA9f1xI/edit?usp=sharing
+[tes-global-talk]: https://www.youtube.com/watch?v=v6wAlxrhC80
+[tes-global-skills-matrix]: https://github.com/tes/app-skills-matrix


### PR DESCRIPTION
* Add GOV.UK as they have published a very comprehensive (if pretty generic) set of career ladders
* Add SkillsMap.io, the first company focused on adding structure around engineering career ladders
* Remove ChartBeats as they no longer publish their engineering ladders.